### PR TITLE
Fix missing initialization of quaternion in priusState_

### DIFF
--- a/car_demo/car_demo/src/PriusControllerRos.cpp
+++ b/car_demo/car_demo/src/PriusControllerRos.cpp
@@ -29,6 +29,7 @@ PriusControllerRos::~PriusControllerRos() = default;
 void PriusControllerRos::initialize(double dt)
 {
   dt_ = dt;
+  priusState_.pose.pose.orientation.w = 1.0;
   createPathTrackerAndLoadParameters();
   loadPIDParameters();
   ROS_INFO_STREAM("PriusControllerRos: Initialization done");


### PR DESCRIPTION
Fix for a warning about non-normalized quaternion in car_demo package