### PR TITLE
Feature/online path update

### DIFF
--- a/pure_pursuit_core/include/pure_pursuit_core/path_tracking/PathTracker.hpp
+++ b/pure_pursuit_core/include/pure_pursuit_core/path_tracking/PathTracker.hpp
@@ -36,6 +36,7 @@ class PathTracker {
 
   bool advance();
   virtual void importCurrentPath(const Path& path);
+  virtual void updateCurrentPath(const Path& path);
   virtual void stopTracking() = 0;
   virtual void updateRobotState(const RobotState& robotState);
   virtual bool initialize();

--- a/pure_pursuit_core/include/pure_pursuit_core/path_tracking/SimplePathTracker.hpp
+++ b/pure_pursuit_core/include/pure_pursuit_core/path_tracking/SimplePathTracker.hpp
@@ -34,6 +34,7 @@ class SimplePathTracker : public PathTracker {
 
   States currentFSMState_ = States::NoOperation;
   bool isPathReceived_ = false;
+  bool isPathUpdated_ = false;
   Stopwatch stopwatch_;
   SimplePathTrackerParameters parameters_;
 };

--- a/pure_pursuit_core/include/pure_pursuit_core/path_tracking/SimplePathTracker.hpp
+++ b/pure_pursuit_core/include/pure_pursuit_core/path_tracking/SimplePathTracker.hpp
@@ -23,6 +23,7 @@ class SimplePathTracker : public PathTracker {
   ~SimplePathTracker() override = default;
 
   void importCurrentPath(const Path& path) override;
+  void updateCurrentPath(const Path& path) override;
   void stopTracking() override;
   void setParameters(const SimplePathTrackerParameters& parameters);
 

--- a/pure_pursuit_core/src/PathTracker.cpp
+++ b/pure_pursuit_core/src/PathTracker.cpp
@@ -47,7 +47,14 @@ double PathTracker::getLongitudinalVelocity() const {
 
 void PathTracker::importCurrentPath(const Path& path) {
   if (path.segment_.empty()) {
-    throw std::runtime_error("empty path");
+    throw std::runtime_error("Trying to import an empty path");
+  }
+  currentPath_ = path;
+}
+
+void PathTracker::updateCurrentPath(const Path& path) {
+  if (path.segment_.empty()) {
+    throw std::runtime_error("Update attempt with empty path");
   }
   currentPath_ = path;
 }

--- a/pure_pursuit_core/src/SimplePathTracker.cpp
+++ b/pure_pursuit_core/src/SimplePathTracker.cpp
@@ -27,6 +27,7 @@ void SimplePathTracker::importCurrentPath(const Path& path) {
   }
   currentPath_ = path;
   isPathReceived_ = true;
+  isPathUpdated_ = false;
   currentPathSegmentId_ = 0;
   currentFSMState_ = States::NoOperation;
 }
@@ -37,8 +38,9 @@ void SimplePathTracker::updateCurrentPath(const Path& path) {
   }
   currentPath_ = path;
   isPathReceived_ = true;
-  currentPathSegmentId_ = 0;           // assume replanning from current position
-  currentFSMState_ = States::Driving;  // keep driving state
+  isPathUpdated_ = true;
+  currentPathSegmentId_ = 0;  // assume replanning from current position
+  // keep current state, do not change it
 }
 
 void SimplePathTracker::advanceStateMachine() {
@@ -71,11 +73,11 @@ void SimplePathTracker::advanceStateMachine() {
     }
   }
 
-  if (currentFSMState_ == States::Driving && isPathReceived_) {
+  if (isPathUpdated_) {
     headingController_->updateCurrentPathSegment(currentPath_.segment_.at(currentPathSegmentId_));
     headingController_->initialize();
     velocityController_->updateCurrentPathSegment(currentPath_.segment_.at(currentPathSegmentId_));
-    std::cout << "Update plan in driving state" << std::endl;
+    std::cout << "Update plan (no state change)" << std::endl;
   }
 
   if (currentFSMState_ == States::NoOperation && isPathReceived_) {
@@ -91,6 +93,7 @@ void SimplePathTracker::advanceStateMachine() {
   }
 
   isPathReceived_ = false;
+  isPathUpdated_ = false;
 }
 
 bool SimplePathTracker::advanceControllers() {

--- a/pure_pursuit_ros/include/pure_pursuit_ros/SimplePathTrackerRos.hpp
+++ b/pure_pursuit_ros/include/pure_pursuit_ros/SimplePathTrackerRos.hpp
@@ -19,6 +19,7 @@ class SimplePathTrackerRos : public SimplePathTracker {
   explicit SimplePathTrackerRos(ros::NodeHandle* nh);
 
   void importCurrentPath(const Path& path) override;
+  void updateCurrentPath(const Path& path) override;
 
  private:
   bool advanceControllers() override;

--- a/pure_pursuit_ros/src/SimplePathTrackerRos.cpp
+++ b/pure_pursuit_ros/src/SimplePathTrackerRos.cpp
@@ -44,6 +44,12 @@ void SimplePathTrackerRos::importCurrentPath(const Path& path) {
   t.detach();
 }
 
+void SimplePathTrackerRos::updateCurrentPath(const Path& path) {
+  BASE::updateCurrentPath(path);
+  std::thread t([this]() { publishPath(currentPath_); });
+  t.detach();
+}
+
 bool SimplePathTrackerRos::advanceControllers() {
   bool status = BASE::advanceControllers();
   std::thread t([this]() { publishRobotPose(); });


### PR DESCRIPTION
This PR introduces an additional function `updateCurrentPath` to the `SimplePathTracker`. It makes it possible to replace a loaded path in the `SimplePathTracker` with a new one while it is executed.
The path is not validated e.g. if start of new trajectory is reasonably close to loaded one. It might be better to add something along these lines. With the currently used pure pursuit controller, it is not really a problem because the controller reacts quite slowly.