### PR TITLE
Feature/se2 grid map generator

### DIFF
--- a/se2_grid_map_generator/CMakeLists.txt
+++ b/se2_grid_map_generator/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_FILES
 set(CATKIN_PACKAGE_DEPENDENCIES
         roscpp
         grid_map_ros
+        se2_grid_map_generator_msgs
         )
 
 find_package(catkin REQUIRED

--- a/se2_grid_map_generator/CMakeLists.txt
+++ b/se2_grid_map_generator/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(se2_grid_map_generator)
+
+set(CMAKE_CXX_STANDARD 14)
+add_compile_options(-Wall -Wextra -Wpedantic)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(SRC_FILES
+        src/GridMapGenerator.cpp
+    )
+
+set(CATKIN_PACKAGE_DEPENDENCIES
+        roscpp
+        grid_map_ros
+        )
+
+find_package(catkin REQUIRED
+        COMPONENTS
+        ${CATKIN_PACKAGE_DEPENDENCIES}
+        )
+
+catkin_package(
+        INCLUDE_DIRS
+        include
+        LIBRARIES
+        CATKIN_DEPENDS
+        ${CATKIN_PACKAGE_DEPENDENCIES}
+)
+
+include_directories(
+        include
+        SYSTEM
+        ${catkin_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}
+            ${SRC_FILES}
+            )
+
+add_dependencies(${PROJECT_NAME}
+        ${catkin_EXPORTED_TARGETS}
+        )
+
+target_link_libraries(${PROJECT_NAME}
+        ${catkin_LIBRARIES}
+        )
+
+add_executable(se2_grid_map_generator_node
+        src/se2_grid_map_generator_node.cpp
+        )
+
+target_link_libraries(se2_grid_map_generator_node
+        ${catkin_LIBRARIES}
+        ${PROJECT_NAME}
+        )

--- a/se2_grid_map_generator/README.md
+++ b/se2_grid_map_generator/README.md
@@ -66,9 +66,10 @@ config/
 
 #### Subscribed Topics 
 
-* **`obstacle`** ([geometry_msgs/Point] )
+* **`obstacle`** ([se2_grid_map_generator_msgs/Obstacle] )
 
-	Desired position of a new obstacle in the map (uses x and y component for position and z for height of obstacle).
+	Desired position and value of the layer in this area of a new obstacle in the map. The elevation layer directly uses 
+    the value (limited from 0 to 1), the traversability layer uses the "inverted value" (1 - value).
 
 * **`nan`** ([geometry_msgs/Point] )
 

--- a/se2_grid_map_generator/README.md
+++ b/se2_grid_map_generator/README.md
@@ -1,0 +1,123 @@
+# se2 grid map generator Package
+
+## Overview
+
+This package is used for generating test elevation maps for the navigation algorithms.
+
+**Keywords:** map generation, grid map, elevation map, test
+
+### License
+
+The source code is released under a [BSD 3-Clause license](ros_package_template/LICENSE).
+
+**Author(s): Christoph Meyer, [meyerc@student.ethz.ch](meyerc@student.ethz.ch)
+**Maintainer:** Edo Jelavic, [jelavice@ethz.ch](jelavice@ethz.ch)
+Affiliation: Robotic Systems Lab, ETH Zurich**
+
+The se2_grid_map_generator package has been tested under [ROS] Melodic and Ubuntu 18.04. This is research code, expect 
+that it changes often and any fitness for a particular purpose is disclaimed.
+
+
+## Installation
+
+### Building from Source
+
+#### Dependencies
+
+- [Robot Operating System (ROS)](http://wiki.ros.org) (middleware for robotics),
+
+#### Building
+
+To build from source, clone the latest version from this repository into your catkin workspace and compile the package using
+
+	cd catkin_ws/src
+	git clone git@bitbucket.org:leggedrobotics/se2_navigation.git	
+	cd ../
+	catkin build se2_grid_map_generator
+
+
+## Usage
+
+Run the main node with
+
+	roslaunch se2_grid_map_generator se2_grid_map_generator.launch
+	
+By publishing a message to the `obstacle`, `nan` or `position` topic the map can be manipulated.
+ 
+    rostopic pub /se2_grid_map_generator_node/obstacle geometry_msgs/Point "{x: 2.0, y: 0.0, z: 1.0}" -1
+
+The z value defines the height of the obstacle (can only vary between 0 and 1).
+    
+## Config files
+
+config/
+
+* **default.rviz:** RViz config.
+
+## Launch files
+
+* **se2_grid_map_generator.launch:** Standard launch file for simulation and real system.
+    
+     - **`launch_rviz`** Enable RViz visualization. Default: `False`.
+     
+## Nodes
+
+* **se2_grid_map_generator_node:**  Publishes a grid map with the desired size and obstacles.
+
+#### Subscribed Topics 
+
+* **`obstacle`** ([geometry_msgs/Point] )
+
+	Desired position of a new obstacle in the map (uses x and y component for position and z for height of obstacle).
+
+* **`nan`** ([geometry_msgs/Point] )
+
+  Desired position of a path with nan values in the map (uses x and y component for position and z is ignored).
+
+* **`position`** ([geometry_msgs/Point] )
+
+	Desired position of the map.
+	
+#### Published Topics
+
+* **`grid_map`** ([grid_map_msgs/GridMap] )
+
+	Grid map message. 
+
+#### Parameters
+
+* **`map/frame_id`** (string, default: "world")
+
+    Frame id of grid map layer.
+    
+* **`map/layer_name`** (string, default: "traversability")
+
+    Layer name of grid map layer.
+    	
+* **`map/resolution`** (float, default: 0.1)
+
+	Topic for pose/odometry input data.
+	
+* **`map/position/x`** (float, default: 5.0)
+
+	Position in reference frame frame_id.
+
+* **`map/position/y`** (float, default: 0.0)
+
+    Position in reference frame frame_id.
+	
+* **`map/length`** (float, default: 20.0)
+
+	Size of map.
+
+* **`map/width`** (float, default: 20.0)
+
+	Size of map.
+	
+* **`obstacle/length`** (float, default: 0.5)
+
+	Length of standard obstacle.
+	
+* **`obstacle/width`** (float, default: 0.5)
+
+	Width of standard obstacle.

--- a/se2_grid_map_generator/config/default.yaml
+++ b/se2_grid_map_generator/config/default.yaml
@@ -1,0 +1,13 @@
+map:
+  frame_id:                     odom
+  elevation_layer_name:         elevation
+  traversability_layer_name:    traversability
+  resolution:                   0.1
+  position:
+    x:                          5.0
+    y:                          0.0
+  length:                       20.0  # x dimension
+  width:                        20.0  # y dimension
+obstacle:
+  length:                       0.50  # x dimension
+  width:                        0.50  # y dimension

--- a/se2_grid_map_generator/config/rviz/default.rviz
+++ b/se2_grid_map_generator/config/rviz/default.rviz
@@ -1,0 +1,154 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 85
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /GridMap1
+      Splitter Ratio: 0.5
+    Tree Height: 685
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+  - Class: se2_planning_rviz/PlanningPanel
+    Name: PlanningPanel
+    controller_command_topic: ""
+    get_current_state_service: ""
+    path_request_topic: /se2_planner_node/ompl_rs_planner_ros/planning_service
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 1
+      Name: Axes
+      Radius: 0.10000000149011612
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: false
+      Class: grid_map_rviz_plugin/GridMap
+      Color: 200; 200; 200
+      Color Layer: traversability
+      Color Transformer: GridMapLayer
+      Enabled: true
+      Height Layer: elevation
+      Height Transformer: GridMapLayer
+      History Length: 1
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 1
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: GridMap
+      Show Grid Lines: true
+      Topic: /se2_grid_map_generator_node/grid_map
+      Unreliable: false
+      Use Rainbow: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 34.54311752319336
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 2.652222156524658
+        Y: -4.9533305168151855
+        Z: -1.1064590215682983
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4447973072528839
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 2.2090654373168945
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1052
+  Hide Left Dock: false
+  Hide Right Dock: true
+  PlanningPanel:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000002d60000036dfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006e00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc000000470000036d000001a901000023fa000000010100000002fb0000001a0050006c0061006e006e0069006e006700500061006e0065006c0100000000ffffffff0000019b00fffffffb000000100044006900730070006c0061007900730100000000000002f60000016100fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000036dfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000470000036d000000c200fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006b500000040fc0100000002fb0000000800540069006d00650100000000000006b50000037100fffffffb0000000800540069006d00650100000000000004500000000000000000000003d80000036d00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1717
+  X: 2400
+  Y: 199

--- a/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
+++ b/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
@@ -1,0 +1,51 @@
+/*
+ * GridMapGenerator.hpp
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: meyerc
+ */
+
+#pragma once
+
+#include <ros/ros.h>
+#include <grid_map_ros/grid_map_ros.hpp>
+
+namespace se2_planning {
+
+class GridMapGenerator {
+public:
+  GridMapGenerator(ros::NodeHandlePtr nh);
+  ~GridMapGenerator() = default;
+
+  void initialize();
+  void initRos();
+  void initMap();
+  void publishMap();
+  bool loadParameters();
+
+protected:
+  void obstacleCb(geometry_msgs::Point position);
+  void nanCb(geometry_msgs::Point position);
+  void positionCb(geometry_msgs::Point position);
+
+  ros::NodeHandlePtr nh_;
+  ros::Subscriber obstacleSub_;
+  ros::Subscriber nanSub_;
+  ros::Subscriber positionSub_;
+  ros::Publisher mapPub_;
+  grid_map::GridMap map_;
+
+private:
+  std::string mapFrameId_;
+  std::string elevationLayerName_;
+  std::string traversabilityLayerName_;
+  double mapResolution_;
+  double mapPositionX_;
+  double mapPositionY_;
+  double mapLength_;
+  double mapWidth_;
+  double obstacleLength_;
+  double obstacleWidth_;
+};
+
+} /* namespace se2_planning */

--- a/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
+++ b/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
@@ -9,6 +9,7 @@
 
 #include <ros/ros.h>
 #include <grid_map_ros/grid_map_ros.hpp>
+#include <se2_grid_map_generator_msgs/Obstacle.h>
 
 namespace se2_planning {
 
@@ -24,7 +25,7 @@ public:
   bool loadParameters();
 
 protected:
-  void obstacleCb(geometry_msgs::Point position);
+  void obstacleCb(se2_grid_map_generator_msgs::Obstacle obstacle);
   void nanCb(geometry_msgs::Point position);
   void positionCb(geometry_msgs::Point position);
   void setRectangleInMap(const std::string layerName, const double x, const double y, const double length,

--- a/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
+++ b/se2_grid_map_generator/include/se2_grid_map_generator/GridMapGenerator.hpp
@@ -27,6 +27,8 @@ protected:
   void obstacleCb(geometry_msgs::Point position);
   void nanCb(geometry_msgs::Point position);
   void positionCb(geometry_msgs::Point position);
+  void setRectangleInMap(const std::string layerName, const double x, const double y, const double length,
+                         const double width, const double value);
 
   ros::NodeHandlePtr nh_;
   ros::Subscriber obstacleSub_;

--- a/se2_grid_map_generator/launch/se2_grid_map_generator.launch
+++ b/se2_grid_map_generator/launch/se2_grid_map_generator.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<launch>
+
+	<!-- Parameters -->
+	<arg name="launch_rviz" default="false" />
+	<arg name="rviz_config_file"
+		 default="$(find se2_grid_map_generator)/config/rviz/default.rviz" />
+
+	<!-- Nodes -->
+	<node name="se2_grid_map_generator_node" pkg="se2_grid_map_generator"
+		  type="se2_grid_map_generator_node" output="screen"
+	      launch-prefix="">
+		<rosparam file="$(find se2_grid_map_generator)/config/default.yaml"/>
+	</node>
+
+	<node name="rviz" pkg="rviz" type="rviz"
+		  args="-d $(arg rviz_config_file)" required="true"
+		  if="$(arg launch_rviz)" />
+
+</launch>

--- a/se2_grid_map_generator/package.xml
+++ b/se2_grid_map_generator/package.xml
@@ -14,5 +14,6 @@
 
   <depend>roscpp</depend>
   <depend>grid_map_ros</depend>
+  <depend>se2_grid_map_generator_msgs</depend>
 
 </package>

--- a/se2_grid_map_generator/package.xml
+++ b/se2_grid_map_generator/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+
+  <name>se2_grid_map_generator</name>
+  <version>0.0.0</version>
+  <description>Package to easily generate test maps for the se2_navigation path planner.</description>
+
+  <author email="meyerc@student.ethz.ch">Christoph Meyer</author>
+  <maintainer email="jelavice@ethz.ch">jelavice</maintainer>
+
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>grid_map_ros</depend>
+
+</package>

--- a/se2_grid_map_generator/src/GridMapGenerator.cpp
+++ b/se2_grid_map_generator/src/GridMapGenerator.cpp
@@ -78,10 +78,10 @@ namespace se2_planning {
     }
   }
 
-  void GridMapGenerator::obstacleCb(geometry_msgs::Point position) {
-    double x = position.x;
-    double y = position.y;
-    double obstacleElevation = std::min(1.0, std::max(position.z, 0.0)); // limit to range 0 to 1
+  void GridMapGenerator::obstacleCb(se2_grid_map_generator_msgs::Obstacle obstacle) {
+    double x = obstacle.position.x;
+    double y = obstacle.position.y;
+    double obstacleElevation = std::min(1.0, std::max(obstacle.value.data, 0.0)); // limit to range 0 to 1
     double obstacleTraversability = 1.0 - obstacleElevation; // limited to range 0 to 1
 
     // Reset elevation layer

--- a/se2_grid_map_generator/src/GridMapGenerator.cpp
+++ b/se2_grid_map_generator/src/GridMapGenerator.cpp
@@ -66,6 +66,18 @@ namespace se2_planning {
     mapPub_.publish(msg);
   }
 
+  void GridMapGenerator::setRectangleInMap(const std::string layerName, const double x, const double y, const double length,
+                                           const double width, const double value) {
+    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
+      grid_map::Position position;
+      map_.getPosition(*iterator, position);
+      if (position.x() < (x + length / 2.0) && position.x() > (x - length / 2.0)
+          && position.y() < (y + width / 2.0) && position.y() > (y - width / 2.0)) {
+        map_.at(layerName, *iterator) = value;
+      }
+    }
+  }
+
   void GridMapGenerator::obstacleCb(geometry_msgs::Point position) {
     double x = position.x;
     double y = position.y;
@@ -74,29 +86,13 @@ namespace se2_planning {
 
     // Reset elevation layer
     map_[elevationLayerName_].setConstant(0.0);
-
-    // Add obstacles to elevation layer
-    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
-      grid_map::Position position;
-      map_.getPosition(*iterator, position);
-      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
-          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
-        map_.at(elevationLayerName_, *iterator) = obstacleElevation;  // height of obstacle
-      }
-    }
+    // Add obstacle to elevation layer
+    setRectangleInMap(elevationLayerName_, x, y, obstacleLength_, obstacleWidth_, obstacleElevation);
 
     // Reset traversability layer
     map_[traversabilityLayerName_].setConstant(1.0);
-
-    // Add obstacles to traversability layer
-    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
-      grid_map::Position position;
-      map_.getPosition(*iterator, position);
-      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
-          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
-        map_.at(traversabilityLayerName_, *iterator) = obstacleTraversability;  // obstacles traversability value
-      }
-    }
+    // Add obstacle to traversability layer
+    setRectangleInMap(traversabilityLayerName_, x, y, obstacleLength_, obstacleWidth_, obstacleTraversability);
 
     publishMap();
   }
@@ -107,29 +103,13 @@ namespace se2_planning {
 
     // Reset elevation layer
     map_[elevationLayerName_].setConstant(0.0);
-
     // Add nans to elevation layer
-    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
-      grid_map::Position position;
-      map_.getPosition(*iterator, position);
-      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
-          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
-        map_.at(elevationLayerName_, *iterator) = std::nanf("");  // unknow cells
-      }
-    }
+    setRectangleInMap(elevationLayerName_, x, y, obstacleLength_, obstacleWidth_, std::nanf(""));
 
     // Reset traversability layer
     map_[traversabilityLayerName_].setConstant(1.0);
-
     // Add nans to traversability layer
-    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
-      grid_map::Position position;
-      map_.getPosition(*iterator, position);
-      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
-          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
-        map_.at(traversabilityLayerName_, *iterator) = std::nanf("");  // unknow cells
-      }
-    }
+    setRectangleInMap(traversabilityLayerName_, x, y, obstacleLength_, obstacleWidth_, std::nanf(""));
 
     publishMap();
   }

--- a/se2_grid_map_generator/src/GridMapGenerator.cpp
+++ b/se2_grid_map_generator/src/GridMapGenerator.cpp
@@ -1,0 +1,145 @@
+/*
+ * GridMapGenerator.cpp
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: meyerc
+ */
+
+#include "se2_grid_map_generator/GridMapGenerator.hpp"
+
+namespace se2_planning {
+
+  GridMapGenerator::GridMapGenerator(ros::NodeHandlePtr nh) : nh_(nh) {}
+
+  void GridMapGenerator::initialize() {
+    if (!loadParameters()) {
+      ROS_ERROR("ROS parameters could not be loaded.");
+    }
+    initRos();
+    initMap();
+    publishMap();
+  }
+
+  void GridMapGenerator::initRos() {
+    mapPub_ = nh_->advertise<grid_map_msgs::GridMap>("grid_map", 1, true);
+    obstacleSub_ = nh_->subscribe("obstacle", 1, &GridMapGenerator::obstacleCb, this);
+    nanSub_ = nh_->subscribe("nan", 1, &GridMapGenerator::nanCb, this);
+    positionSub_ = nh_->subscribe("position", 1, &GridMapGenerator::positionCb, this);
+  }
+
+  bool GridMapGenerator::loadParameters() {
+    if (!nh_->getParam("map/frame_id", mapFrameId_)) return false;
+    if (!nh_->getParam("map/elevation_layer_name", elevationLayerName_)) return false;
+    if (!nh_->getParam("map/traversability_layer_name", traversabilityLayerName_)) return false;
+    if (!nh_->getParam("map/resolution", mapResolution_)) return false;
+    if (!nh_->getParam("map/position/x", mapPositionX_)) return false;
+    if (!nh_->getParam("map/position/y", mapPositionY_)) return false;
+    if (!nh_->getParam("map/length", mapLength_)) return false;
+    if (!nh_->getParam("map/width", mapWidth_)) return false;
+    if (!nh_->getParam("obstacle/length", obstacleLength_)) return false;
+    if (!nh_->getParam("obstacle/width", obstacleWidth_)) return false;
+    if (obstacleLength_ / 2.0 < mapResolution_) {
+      ROS_ERROR_STREAM("obstacle_length " << obstacleLength_ << " is too small for chosen map_resolution "
+                                          << mapResolution_ << ". Minimum is two times the map_resolution.");
+      return false;
+    }
+    if (obstacleWidth_ / 2.0 < mapResolution_) {
+      ROS_ERROR_STREAM("obstacle_width " << obstacleWidth_ << " is too small for chosen map_resolution "
+                                         << mapResolution_ << ". Minimum is two times the map_resolution.");
+      return false;
+    }
+    return true;
+  }
+
+  void GridMapGenerator::initMap() {
+    map_.setFrameId(mapFrameId_);
+    map_.setTimestamp(ros::Time::now().toNSec());
+    map_.setGeometry(grid_map::Length(mapLength_, mapWidth_), mapResolution_,
+                     grid_map::Position(mapPositionX_, mapPositionY_));
+    map_.add(elevationLayerName_, 0.0);       // elevation neutral value is 0.0
+    map_.add(traversabilityLayerName_, 1.0);  // traversability neutral value is 1.0
+  }
+
+  void GridMapGenerator::publishMap() {
+    grid_map_msgs::GridMap msg;
+    grid_map::GridMapRosConverter::toMessage(map_, msg);
+    mapPub_.publish(msg);
+  }
+
+  void GridMapGenerator::obstacleCb(geometry_msgs::Point position) {
+    double x = position.x;
+    double y = position.y;
+    double obstacleElevation = std::min(1.0, std::max(position.z, 0.0)); // limit to range 0 to 1
+    double obstacleTraversability = 1.0 - obstacleElevation; // limited to range 0 to 1
+
+    // Reset elevation layer
+    map_[elevationLayerName_].setConstant(0.0);
+
+    // Add obstacles to elevation layer
+    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
+      grid_map::Position position;
+      map_.getPosition(*iterator, position);
+      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
+          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
+        map_.at(elevationLayerName_, *iterator) = obstacleElevation;  // height of obstacle
+      }
+    }
+
+    // Reset traversability layer
+    map_[traversabilityLayerName_].setConstant(1.0);
+
+    // Add obstacles to traversability layer
+    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
+      grid_map::Position position;
+      map_.getPosition(*iterator, position);
+      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
+          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
+        map_.at(traversabilityLayerName_, *iterator) = obstacleTraversability;  // obstacles traversability value
+      }
+    }
+
+    publishMap();
+  }
+
+  void GridMapGenerator::nanCb(geometry_msgs::Point position) {
+    double x = position.x;
+    double y = position.y;
+
+    // Reset elevation layer
+    map_[elevationLayerName_].setConstant(0.0);
+
+    // Add nans to elevation layer
+    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
+      grid_map::Position position;
+      map_.getPosition(*iterator, position);
+      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
+          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
+        map_.at(elevationLayerName_, *iterator) = std::nanf("");  // unknow cells
+      }
+    }
+
+    // Reset traversability layer
+    map_[traversabilityLayerName_].setConstant(1.0);
+
+    // Add nans to traversability layer
+    for (grid_map::GridMapIterator iterator(map_); !iterator.isPastEnd(); ++iterator) {
+      grid_map::Position position;
+      map_.getPosition(*iterator, position);
+      if (position.x() < (x + obstacleLength_ / 2.0) && position.x() > (x - obstacleLength_ / 2.0)
+          && position.y() < (y + obstacleWidth_ / 2.0) && position.y() > (y - obstacleWidth_ / 2.0)) {
+        map_.at(traversabilityLayerName_, *iterator) = std::nanf("");  // unknow cells
+      }
+    }
+
+    publishMap();
+  }
+
+  void GridMapGenerator::positionCb(geometry_msgs::Point position) {
+    grid_map::Position mapPosition;
+    mapPosition.x() = position.x;
+    mapPosition.y() = position.y;
+    map_.setPosition(mapPosition);
+    publishMap();
+  }
+
+} /* namespace se2_planning */

--- a/se2_grid_map_generator/src/se2_grid_map_generator_node.cpp
+++ b/se2_grid_map_generator/src/se2_grid_map_generator_node.cpp
@@ -1,0 +1,28 @@
+/*
+ * se2_grid_map_generator_node.cpp
+ *
+ *  Created on: Feb 4, 2021
+ *      Author: meyerc
+ */
+
+#include <ros/ros.h>
+
+#include "se2_grid_map_generator/GridMapGenerator.hpp"
+
+// Start node on the command line and then use in a second terminal
+//  rostopic pub /se2_grid_map_generator_node/obstacle geometry_msgs/Point "{x: 1.0, y: 0.0, z: 1.0}" -1
+// to trigger a new map, the z value defines the height of the obstacle (can only vary between 0 and 1).
+
+int main(int argc, char** argv) {
+  using namespace se2_planning;
+
+  ros::init(argc, argv, "se2_grid_map_generator_node");
+  ros::NodeHandlePtr nh(new ros::NodeHandle("~"));
+
+  GridMapGenerator mapGenerator = GridMapGenerator(nh);
+  mapGenerator.initialize();
+
+  ros::spin();
+
+  return 0;
+}

--- a/se2_grid_map_generator_msgs/CMakeLists.txt
+++ b/se2_grid_map_generator_msgs/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(se2_grid_map_generator_msgs)
+
+add_definitions(-std=c++11)
+
+
+set(CATKIN_PACKAGE_DEPENDENCIES
+    std_msgs
+    geometry_msgs
+)
+
+find_package(catkin REQUIRED COMPONENTS
+  ${CATKIN_PACKAGE_DEPENDENCIES}
+  message_generation
+)
+
+
+add_message_files( 
+   FILES
+     Obstacle.msg
+)
+
+generate_messages(
+    DEPENDENCIES
+      ${CATKIN_PACKAGE_DEPENDENCIES}
+)
+
+catkin_package(
+        INCLUDE_DIRS
+        CATKIN_DEPENDS
+        ${CATKIN_PACKAGE_DEPENDENCIES}
+        message_runtime
+)

--- a/se2_grid_map_generator_msgs/README.md
+++ b/se2_grid_map_generator_msgs/README.md
@@ -1,0 +1,16 @@
+# se2\_grid\_map\_generator\_msgs
+
+Collection of messages and services for communication with grid map generator.
+
+## Messages
+----------- 
+      
+#### Obstacle (Obstacle.msg)  
++  *geometry_msgs/Position position*   
++  *std_msgs/Float64[] value*
+ 
+## Dependencies
+
+* std_msgs
+
+* geometry_msgs

--- a/se2_grid_map_generator_msgs/msg/Obstacle.msg
+++ b/se2_grid_map_generator_msgs/msg/Obstacle.msg
@@ -1,0 +1,3 @@
+
+geometry_msgs/Point position
+std_msgs/Float64 value

--- a/se2_grid_map_generator_msgs/package.xml
+++ b/se2_grid_map_generator_msgs/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+
+  <name>se2_grid_map_generator_msgs</name>
+  <version>0.0.0</version>
+  <description>Messages for planners and controllers.</description>
+
+  <maintainer email="jelavice@ethz.ch">jelavice</maintainer>
+
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>message_generation</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <exec_depend>message_runtime</exec_depend>
+
+</package>


### PR DESCRIPTION
I have created a first version of a separate node se2_grid_map_generator_node to generate grid_maps to debug the behavior of the planner without the need for any rosbag or simulate sensor. This is useful for the upcoming PR to have online map updates.

It is possible to send messages to the node to modify the map which is then published to a desired topic. See README.

The entire node is very specific for the se2_navigation package. Let me know if you have any ideas how to generalize it. If you think this is useful, we could also add an RViz plugin for it. Similar to the one for se2_navigation package. Maybe we should also use a different name since it does not have any relation to the se2 space...